### PR TITLE
Various improvements and fixes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -811,7 +811,7 @@ class LambdaForm {
         if (this.vmentry != null) {
             return; // already resolved or already prepared (e.g. lform from cache)
         }
-        if (RESOLVE_LAZY) {
+        if (RESOLVE_LAZY && LambdaFormResolvers.canResolve(this.kind)) {
             this.vmentry = LambdaFormResolvers.resolverFor(this);
         } else {
             resolve();


### PR DESCRIPTION
- Avoid DMH for basicInvoker: gets rid of a solid chunk of LF classes while still compiling down to the same bytecode
  (might be possible to improve further by not re-resolving the polymorphic signature method all the time but instead adding a MemberName constructor that just takes a pre-resolved version of a polymorphic type and creates a new one with a new MethodType..)
- don't lazy resolve RESOLVERs: fixed a bootstrap cycle that led to crashes during build 
- rearrange cache code so that pre-generated resolved types are stored in and retrieved from cache