### PR TITLE
Add jlink pregeneration support

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -751,7 +751,6 @@ class InvokerBytecodeGenerator {
             case DIRECT_INVOKE_STATIC:      // fall-through
             case DIRECT_INVOKE_STATIC_INIT: // fall-through
             case DIRECT_INVOKE_VIRTUAL:     return resolveFrom(name, invokerType, DirectMethodHandle.Holder.class);
-            case RESOLVER:                  return resolveFrom(name, invokerType, LambdaFormResolvers.Holder.class);
         }
         return null;
     }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -695,7 +695,7 @@ class InvokerBytecodeGenerator {
         return lastInternalName = c.getName().replace('.', '/');
     }
 
-    private static MemberName resolveFrom(String name, MethodType type, Class<?> holder) {
+    static MemberName resolveFrom(String name, MethodType type, Class<?> holder) {
         assert(!UNSAFE.shouldBeInitialized(holder)) : holder + "not initialized";
         MemberName member = new MemberName(holder, name, type, REF_invokeStatic);
         MemberName resolvedMember = MemberName.getFactory().resolveOrNull(REF_invokeStatic, member, holder, LM_TRUSTED);
@@ -751,6 +751,7 @@ class InvokerBytecodeGenerator {
             case DIRECT_INVOKE_STATIC:      // fall-through
             case DIRECT_INVOKE_STATIC_INIT: // fall-through
             case DIRECT_INVOKE_VIRTUAL:     return resolveFrom(name, invokerType, DirectMethodHandle.Holder.class);
+            case RESOLVER:                  return resolveFrom(name, invokerType, LambdaFormResolvers.Holder.class);
         }
         return null;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleStatics.java
@@ -62,7 +62,6 @@ class MethodHandleStatics {
     static final int CUSTOMIZE_THRESHOLD;
     static final boolean RESOLVE_LAZY;
     static final boolean TRACE_RESOLVERS;
-    static final boolean USE_PRE_GEN_RESOLVERS;
     static final boolean VAR_HANDLE_GUARDS;
     static final boolean VAR_HANDLE_IDENTITY_ADAPT;
     static final int MAX_ARITY;
@@ -95,8 +94,6 @@ class MethodHandleStatics {
                 props.getProperty("java.lang.invoke.MethodHandle.RESOLVE_LAZY", "true"));
         TRACE_RESOLVERS = Boolean.parseBoolean(
                 props.getProperty("java.lang.invoke.MethodHandle.TRACE_RESOLVERS"));
-        USE_PRE_GEN_RESOLVERS = Boolean.parseBoolean(
-                props.getProperty("java.lang.invoke.MethodHandle.USE_PRE_GEN_RESOLVERS", "true"));
         VAR_HANDLE_GUARDS = Boolean.parseBoolean(
                 props.getProperty("java.lang.invoke.VarHandle.VAR_HANDLE_GUARDS", "true"));
         VAR_HANDLE_IDENTITY_ADAPT = Boolean.parseBoolean(

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -194,7 +194,6 @@ final class MethodTypeForm {
             this.parameterSlotCount = (short)pslotCount;
             this.lambdaForms   = new SoftReference[LF_LIMIT];
             this.methodHandles = new SoftReference[MH_LIMIT];
-            this.memberNames   = new SoftReference[MN_LIMIT];
         } else {
             this.basicType = MethodType.methodType(basicReturnType, basicPtypes, true);
             // fill in rest of data from the basic type:
@@ -205,7 +204,6 @@ final class MethodTypeForm {
             this.primitiveCount = that.primitiveCount;
             this.methodHandles = null;
             this.lambdaForms = null;
-            this.memberNames = null;
         }
     }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/GenerateJLIClassesPlugin.java
@@ -121,7 +121,7 @@ public final class GenerateJLIClassesPlugin extends AbstractPlugin {
     @Override
     public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
         initialize(in);
-        // Copy all but DMH_ENTRY to out
+        // Copy all but the Holder classes to out
         in.transformAndCopy(entry -> {
                 // No trace file given.  Copy all entries.
                 if (traceFileStream == null) return entry;
@@ -131,7 +131,8 @@ public final class GenerateJLIClassesPlugin extends AbstractPlugin {
                 if (path.equals(DIRECT_METHOD_HOLDER_ENTRY) ||
                     path.equals(DELEGATING_METHOD_HOLDER_ENTRY) ||
                     path.equals(INVOKERS_HOLDER_ENTRY) ||
-                    path.equals(BASIC_FORMS_HOLDER_ENTRY)) {
+                    path.equals(BASIC_FORMS_HOLDER_ENTRY) ||
+                    path.equals(RESOLVERS_HOLDER_ENTRY)) {
                     return null;
                 } else {
                     return entry;
@@ -162,4 +163,7 @@ public final class GenerateJLIClassesPlugin extends AbstractPlugin {
             "/java.base/java/lang/invoke/LambdaForm$Holder.class";
     private static final String INVOKERS_HOLDER_ENTRY =
             "/java.base/java/lang/invoke/Invokers$Holder.class";
+
+    private static final String RESOLVERS_HOLDER_ENTRY =
+            "/java.base/java/lang/invoke/LambdaFormResolvers$Holder.class";
 }


### PR DESCRIPTION
- Revert to a LambdaForm cache for Resolvers,
- which then enables piggy-backing on existing code for lookups and pregeneration in GenerateJLIClassesPlugin/-Helper
- Some minor cleanups in nearby code

Verified all resolvers are loaded in simple tests. On large tests we see a time penalty since we now do many more failed speculatively resolves. Perhaps time to make the speculative resolves less speculative.