### PR TITLE
Fix for JDK-8296973

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequence.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequence.java
@@ -191,6 +191,10 @@ public class CallingSequence {
                 .reduce(0, (a, b) -> a | b);
     }
 
+    public int numLeadingParams() {
+        return 2 + (linkerOptions.hasCapturedCallState() ? 1 : 0); // 2 for addr, allocator
+    }
+
     public String asString() {
         StringBuilder sb = new StringBuilder();
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -152,7 +152,7 @@ public abstract class CallArranger {
         MethodHandle handle = new DowncallLinker(C, bindings.callingSequence).getBoundMethodHandle();
 
         if (bindings.isInMemoryReturn) {
-            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc, bindings.callingSequence);
         }
 
         return handle;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -126,7 +126,7 @@ public class CallArranger {
         handle = MethodHandles.insertArguments(handle, handle.type().parameterCount() - 1, bindings.nVectorArgs);
 
         if (bindings.isInMemoryReturn) {
-            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc, bindings.callingSequence);
         }
 
         return handle;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -125,7 +125,7 @@ public class CallArranger {
         MethodHandle handle = new DowncallLinker(CWindows, bindings.callingSequence).getBoundMethodHandle();
 
         if (bindings.isInMemoryReturn) {
-            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc, bindings.callingSequence);
         }
 
         return handle;

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -35,15 +35,21 @@ import org.testng.annotations.Test;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
+import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.testng.Assert.assertEquals;
 
 public class TestCaptureCallState extends NativeTestHelper {
@@ -57,19 +63,23 @@ public class TestCaptureCallState extends NativeTestHelper {
         }
     }
 
-    private record SaveValuesCase(String nativeTarget, String threadLocalName) {}
+    private record SaveValuesCase(String nativeTarget, FunctionDescriptor nativeDesc, String threadLocalName, Consumer<Object> resultCheck) {}
 
     @Test(dataProvider = "cases")
     public void testSavedThreadLocal(SaveValuesCase testCase) throws Throwable {
         Linker.Option.CaptureCallState stl = Linker.Option.captureCallState(testCase.threadLocalName());
-        MethodHandle handle = downcallHandle(testCase.nativeTarget(), FunctionDescriptor.ofVoid(JAVA_INT), stl);
+        MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), stl);
 
         VarHandle errnoHandle = stl.layout().varHandle(groupElement(testCase.threadLocalName()));
 
         try (Arena arena = Arena.openConfined()) {
             MemorySegment saveSeg = arena.allocate(stl.layout());
             int testValue = 42;
-            handle.invoke(saveSeg, testValue);
+            boolean needsAllocator = testCase.nativeDesc().returnLayout().map(StructLayout.class::isInstance).orElse(false);
+            Object result = needsAllocator
+                ? handle.invoke(arena, saveSeg, testValue)
+                : handle.invoke(saveSeg, testValue);
+            testCase.resultCheck().accept(result);
             int savedErrno = (int) errnoHandle.get(saveSeg);
             assertEquals(savedErrno, testValue);
         }
@@ -79,13 +89,43 @@ public class TestCaptureCallState extends NativeTestHelper {
     public static Object[][] cases() {
         List<SaveValuesCase> cases = new ArrayList<>();
 
-        cases.add(new SaveValuesCase("set_errno", "errno"));
+        cases.add(new SaveValuesCase("set_errno_V", FunctionDescriptor.ofVoid(JAVA_INT), "errno", o -> {}));
+        cases.add(new SaveValuesCase("set_errno_I", FunctionDescriptor.of(JAVA_INT, JAVA_INT), "errno", o -> assertEquals((int) o, 42)));
+        cases.add(new SaveValuesCase("set_errno_D", FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT), "errno", o -> assertEquals((double) o, 42.0)));
+
+        cases.add(structCase("SL",  Map.of(JAVA_LONG.withName("x"), 42L)));
+        cases.add(structCase("SLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                           JAVA_LONG.withName("y"), 42L)));
+        cases.add(structCase("SLLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                            JAVA_LONG.withName("y"), 42L,
+                                            JAVA_LONG.withName("z"), 42L)));
+        cases.add(structCase("SD",  Map.of(JAVA_DOUBLE.withName("x"), 42D)));
+        cases.add(structCase("SDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                           JAVA_DOUBLE.withName("y"), 42D)));
+        cases.add(structCase("SDDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                            JAVA_DOUBLE.withName("y"), 42D,
+                                            JAVA_DOUBLE.withName("z"), 42D)));
+
         if (IS_WINDOWS) {
-            cases.add(new SaveValuesCase("SetLastError", "GetLastError"));
-            cases.add(new SaveValuesCase("WSASetLastError", "WSAGetLastError"));
+            cases.add(new SaveValuesCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {}));
+            cases.add(new SaveValuesCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {}));
         }
 
         return cases.stream().map(tc -> new Object[] {tc}).toArray(Object[][]::new);
+    }
+
+    static SaveValuesCase structCase(String name, Map<MemoryLayout, Object> fields) {
+        StructLayout layout = MemoryLayout.structLayout(fields.keySet().toArray(MemoryLayout[]::new));
+
+        Consumer<Object> check = o -> {};
+        for (var field : fields.entrySet()) {
+            MemoryLayout fieldLayout = field.getKey();
+            VarHandle fieldHandle = layout.varHandle(MemoryLayout.PathElement.groupElement(fieldLayout.name().get()));
+            Object value = field.getValue();
+            check = check.andThen(o -> assertEquals(fieldHandle.get(o), value));
+        }
+
+        return new SaveValuesCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
     }
 
 }

--- a/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
+++ b/test/jdk/java/foreign/capturecallstate/libCaptureCallState.c
@@ -29,6 +29,94 @@
 #define EXPORT
 #endif
 
-EXPORT void set_errno(int value) {
+EXPORT void set_errno_V(int value) {
     errno = value;
+}
+
+EXPORT int set_errno_I(int value) {
+    errno = value;
+    return 42;
+}
+
+EXPORT double set_errno_D(int value) {
+    errno = value;
+    return 42.0;
+}
+
+struct SL {
+    long long x;
+};
+
+EXPORT struct SL set_errno_SL(int value) {
+    errno = value;
+    struct SL s;
+    s.x = 42;
+    return s;
+}
+
+struct SLL {
+    long long x;
+    long long y;
+};
+
+EXPORT struct SLL set_errno_SLL(int value) {
+    errno = value;
+    struct SLL s;
+    s.x = 42;
+    s.y = 42;
+    return s;
+}
+
+struct SLLL {
+    long long x;
+    long long y;
+    long long z;
+};
+
+EXPORT struct SLLL set_errno_SLLL(int value) {
+    errno = value;
+    struct SLLL s;
+    s.x = 42;
+    s.y = 42;
+    s.z = 42;
+    return s;
+}
+
+struct SD {
+    double x;
+};
+
+EXPORT struct SD set_errno_SD(int value) {
+    errno = value;
+    struct SD s;
+    s.x = 42.0;
+    return s;
+}
+
+struct SDD {
+    double x;
+    double y;
+};
+
+EXPORT struct SDD set_errno_SDD(int value) {
+    errno = value;
+    struct SDD s;
+    s.x = 42.0;
+    s.y = 42.0;
+    return s;
+}
+
+struct SDDD {
+    double x;
+    double y;
+    double z;
+};
+
+EXPORT struct SDDD set_errno_SDDD(int value) {
+    errno = value;
+    struct SDDD s;
+    s.x = 42.0;
+    s.y = 42.0;
+    s.z = 42.0;
+    return s;
 }


### PR DESCRIPTION
fix for [JDK-8296973](https://bugs.openjdk.org/browse/JDK-8296973)

There are 2 bugs:
- frame allocation code is not in the right order, meaning that the return register spill can overwrite some of the special values in a downcall stub frame
- CaptureCallState adds an additional leading parameter, which can mess up `SharedUtils::adaptDowncallForIMR`.

Both are fixed in this patch