### PR TITLE
Safer publication of the resolved LF

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormResolvers.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormResolvers.java
@@ -27,6 +27,7 @@ package java.lang.invoke;
 import java.lang.invoke.LambdaForm.Name;
 import java.lang.invoke.LambdaForm.NamedFunction;
 import java.util.Arrays;
+import java.util.function.Function;
 
 import static java.lang.invoke.LambdaForm.arguments;
 import static java.lang.invoke.MethodHandleNatives.Constants.REF_invokeVirtual;
@@ -107,7 +108,13 @@ class LambdaFormResolvers {
         }
 
         public static void resolve(MethodHandle mh) {
-            mh.form.resolve(mh.form.methodType());
+            LambdaForm oldForm = mh.form;
+            MemberName vmentry = oldForm.resolve(oldForm.methodType());
+            mh.updateForm(new Function<>() {
+                public LambdaForm apply(LambdaForm oldForm) {
+                    return new LambdaForm(oldForm, vmentry);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Structuring so that the `LF::resolve` returns the membername, which is then properly installed into the outer mh by means of `mh::updateForm`. This is a plausible or at least partial fix to a safe publication issue where the LF might end up in an inconsistent state, and with this change `make test TEST=jdk_foreign` has passed 10 times in a row for me. To be ideal we should refactor compileBytecode et.c. to not side-effect `lf.vmentry` etc directly. We should also re-examine `isResolved` since it might be redundant with this protocol